### PR TITLE
Repair and update current functionality for `eva` file modification

### DIFF
--- a/statemodify/__init__.py
+++ b/statemodify/__init__.py
@@ -1,4 +1,6 @@
 from .ddm import *
 from .eva import *
+from .sampler import *
+from .utils import *
 
 __version__ = "0.0.0"

--- a/statemodify/data/template_scenario-test_sample-0.eva
+++ b/statemodify/data/template_scenario-test_sample-0.eva
@@ -1,0 +1,47 @@
+#
+# evadat.                                                                                                                                       
+# net reservoir evaporation annual data                                                                                                         
+#                                                                                                                                               
+# *******************************************************                                                                                       
+#                                                                                                                                               
+#     Card 1   Control                                                                                                                          
+#     format:  (5x, a12, 12f8.0                                                                                                                 
+#                                                                                                                                               
+#     ID       cistat:          Station id                                                                                                      
+#              diverm(1-12):    Evap by month                                                                                                   
+#                                                                                                                                               
+# Oct-Sept units in feet                                                                                                                        
+# 1 yampa,                                                                                                                                      
+# 2 white,                                                                                                                                      
+# 3 dolores/san miguel (mcphee),                                                                                                                
+# 4 san juan (navajo reservoir), Modified to reflect BuRec evap 10/9/98 ra                                                                                                                
+# 5 colorado (rifle gap),                                                                                                                       
+# 6 colorado (ruedi, vega),                                                                                                                     
+# 7 sanjuan,                                                                                                                                    
+# 8 colorado (dillon, williams fork),                                                                                                           
+# 9 colorado (shadow mt, granby, willow crk)                                                                                                    
+#10 gunnison (taylor park)                                                                                                                      
+#11 gunnison (blue mesa, paonia)                                                                                                                
+#12 gunnison (ridgeway)                                                                                                                         
+# 01-03-96: added a ninth evaporation curve for the extreme upper Colorado basin (10009).                                                       
+# This curve was developed from the evaporation pan located at Shadow Mountain Reservoir which reports                                          
+# an annual average gross pan evaporation of 40 inches and a pan coefficient of 0.75 which yields an annual                                     
+# average gross free water surface evaporation value of 30 inches.  Evaporation curve 10008 was developed using                                 
+# 35 inches of gross annual free water survace evaporation.  Curve 10009 was developed by multiplying                                           
+# curve 10008 by the ratio 30/35.                                                                                                               
+#                                                                                                                                               
+# NA ID               Oct     Nov     Dec     Jan     Feb     Mar     Apr     May     Jun     Jul     Aug     Sep                               
+# -e-b----------eb------eb------eb------eb------eb------eb------eb------eb------eb------eb------eb------eb------eb                              
+   10/   0  -      9/   0   FT  WYR                                                                                                                        
+     10001         0.0511 -0.0039 -0.0432 -0.0472 -0.0118  0.0236  0.0589    0.11  0.1572  0.1532   0.114  0.0982
+     10002           0.13    0.04   -0.05   -0.06    0.02    0.09    0.16     0.3    0.41    0.41    0.27    0.24
+     10003           0.13    0.04   -0.02   -0.03    0.05    0.11    0.22    0.33    0.48    0.43    0.32    0.28
+     10004         0.0535  0.0262  0.0189  0.0187  0.0233  0.0483  0.0759  0.1086  0.1317  0.1408  0.0821  0.0885
+     10005        -0.0556 -0.0257 -0.0086 -0.0128 -0.0257  -0.047 -0.0941 -0.1369 -0.1796 -0.1754 -0.1497 -0.1027
+     10006        -0.0556 -0.0086  0.0385  0.0428  0.0086 -0.0299 -0.0727 -0.1369 -0.1754 -0.1796  -0.124 -0.1027
+     10007           0.03   -0.15   -0.16   -0.08   -0.07   -0.01    0.15    0.29    0.41    0.29    0.07    0.08
+     10008           0.14    0.03   -0.05   -0.05    0.01    0.06    0.16    0.25    0.35    0.32    0.26    0.22
+     10009           0.03    0.01   -0.06   -0.06    0.01    0.05    0.07    0.29    0.38    0.32    0.22    0.08
+     10010           0.08    0.01   -0.02   -0.01    0.01    0.04    0.12    0.18    0.24    0.21    0.18    0.16
+     10011           0.14    0.07    0.02    0.03    0.05    0.13    0.24    0.33     0.4    0.35    0.31    0.29
+     10012           0.08   -0.02    0.05    0.04    0.06    0.02    0.19    0.31    0.44    0.33    0.28    0.18

--- a/statemodify/eva.py
+++ b/statemodify/eva.py
@@ -170,7 +170,7 @@ def modify_single_eva(modify_dict: Dict[str, List[Union[str, float]]],
     :param sample:              An array of samples for each parameter.
     :type sample:               np.array
 
-    :param sample_id:           Numeric ID of sample that is being procecessed. Defaults to 0.
+    :param sample_id:           Numeric ID of sample that is being processed. Defaults to 0.
     :type sample_id:            int
 
     :param output_dir:          Path to output directory.
@@ -216,7 +216,7 @@ def modify_single_eva(modify_dict: Dict[str, List[Union[str, float]]],
         sample_id = 0
 
         # sample array for each parameter
-        sample = np.array([[1.0], [1.2]])
+        sample = np.array([0.39, -0.42])
 
         # seed value for reproducibility if so desired
         seed_value = None

--- a/statemodify/eva.py
+++ b/statemodify/eva.py
@@ -204,7 +204,6 @@ def modify_single_eva(modify_dict: Dict[str, List[Union[str, float]]],
 
         # a dictionary to describe what you want to modify and the bounds for the LHS
         setup_dict = {
-            "names": ["municipal", "standard"],
             "ids": [["10001", "10004"], ["10005", "10006"]],
             "bounds": [[-1.0, 1.0], [-1.0, 1.0]]
         }
@@ -347,7 +346,6 @@ def modify_eva(modify_dict: Dict[str, List[Union[str, float]]],
 
         # a dictionary to describe what you want to modify and the bounds for the LHS
         setup_dict = {
-            "names": ["municipal", "standard"],
             "ids": [["10001", "10004"], ["10005", "10006"]],
             "bounds": [[-1.0, 1.0], [-1.0, 1.0]]
         }
@@ -385,7 +383,7 @@ def modify_eva(modify_dict: Dict[str, List[Union[str, float]]],
     """
 
     # build a probelm dictionary for use by SALib
-    problem_dict = sampler.build_problem_dict(modify_dict)
+    problem_dict = sampler.build_problem_dict(modify_dict, fill=True)
 
     # generate a sample array
     sample_array = sampler.generate_samples(problem_dict=problem_dict,

--- a/statemodify/sampler.py
+++ b/statemodify/sampler.py
@@ -24,7 +24,7 @@ def validate_modify_dict(modify_dict: Dict[str, List[Union[str, float]]],
             print(f"Filling names field for 'modify_dict' with generic ID as it is not used in this function.")
             modify_dict["names"] = [f"group_{index}" for index, i in enumerate(modify_dict["ids"])]
 
-        elif (key not in modify_dict):
+        elif key not in modify_dict:
             raise KeyError(f"Missing the following key in user provided modify dictionary:  '{key}'")
 
     return modify_dict

--- a/statemodify/sampler.py
+++ b/statemodify/sampler.py
@@ -88,7 +88,7 @@ def generate_samples(problem_dict: dict,
 
         return latin.sample(problem=problem_dict,
                             N=n_samples,
-                            seed=seed_value).T
+                            seed=seed_value)
 
     else:
         raise KeyError(f"Selected sampling method is not currently supported.  Please file a feature request here: https://github.com/IMMM-SFA/statemodify/issues")

--- a/statemodify/sampler.py
+++ b/statemodify/sampler.py
@@ -11,6 +11,9 @@ def validate_modify_dict(modify_dict: Dict[str, List[Union[str, float]]],
     :param modify_dict:         Dictionary of parameters to setup the sampler.
     :type modify_dict:          Dict[str, List[Union[str, float]]]
 
+    :param fill:                If True, fill in missing names using the index of the ids list. Default False.
+    :type fill:                 bool
+
     :returns:                   Dictionary of validated parameters
     :rtype:                     dict
 
@@ -21,7 +24,7 @@ def validate_modify_dict(modify_dict: Dict[str, List[Union[str, float]]],
 
     for key in required_keys:
         if (key not in modify_dict) and (key == "names") and (fill is True):
-            print(f"Filling names field for 'modify_dict' with generic ID as it is not used in this function.")
+            print(f"Filling 'names' field for 'modify_dict' with generic names as they are not used in this function.")
             modify_dict["names"] = [f"group_{index}" for index, i in enumerate(modify_dict["ids"])]
 
         elif key not in modify_dict:

--- a/statemodify/sampler.py
+++ b/statemodify/sampler.py
@@ -1,0 +1,94 @@
+from typing import Union, Dict, List
+
+import numpy as np
+from SALib.sample import latin
+
+
+def validate_modify_dict(modify_dict) -> None:
+    """Validate user input modify dictionary to ensure all necessary elements are present.
+
+    :param modify_dict:         Dictionary of parameters to setup the sampler.
+    :type modify_dict:          Dict[str, List[Union[str, float]]]
+
+    :returns:                   None
+    :rtype:                     None
+
+    """
+
+    required_keys = ("names", "ids", "bounds")
+
+    for key in required_keys:
+        if key not in modify_dict:
+            raise KeyError(f"Missing the following key in user provided modify dictionary:  '{key}'")
+
+
+def build_problem_dict(modify_dict) -> dict:
+    """Build the problem set from the input modify dictionary provided by the user.
+
+    :param modify_dict:         Dictionary of parameters to setup the sampler.
+    :type modify_dict:          Dict[str, List[Union[str, float]]]
+
+    :returns:                   Dictionary ready for use by SALib sample generators
+    :rtype:                     dict
+
+    :example:
+
+    .. code-block:: python
+
+        import statemodify as stm
+
+        # a dictionary to describe what you want to modify and the bounds for the LHS
+        setup_dict = {
+            "names": ["municipal", "standard"],
+            "ids": [["10001", "10004"], ["10005", "10006"]],
+            "bounds": [[-1.0, 1.0], [-1.0, 1.0]]
+        }
+
+        # generate problem dictionary to use with SALib sampling components
+        problem_dict = stm.build_problem_dict(modify_dict)
+
+    """
+
+    # ensure all keys are present in the user provided dictionary
+    validate_modify_dict(modify_dict)
+
+    return {
+        'num_vars': len(modify_dict["names"]),
+        'names': modify_dict["names"],
+        'bounds': modify_dict["bounds"]
+    }
+
+
+def generate_samples(problem_dict: dict,
+                     n_samples: int = 1,
+                     sampling_method: str = "LHS",
+                     seed_value: Union[None, int] = None) -> np.array:
+    """Generate an array of statistically generated samples.
+
+    :param problem_dict:        Dictionary of parameters to setup the sampler.
+    :type problem_dict:         Dict[str, List[Union[str, float]]]
+
+    :param sampling_method:     Sampling method.  Uses SALib's implementation (see https://salib.readthedocs.io/en/latest/).
+                                Currently supports the following method:  "LHS" for Latin Hypercube Sampling
+    :type sampling_method:      str
+
+    :param n_samples:           Number of LHS samples to generate, optional. Defaults to 1.
+    :type n_samples:            int, optional
+
+    :param seed_value:          Seed value to use when generating samples for the purpose of reproducibility.
+                                Defaults to None.
+    :type seed_value:           Union[None, int], optional
+
+    :returns:                   Array of samples
+    :rtype:                     np.array
+
+    """
+
+    if sampling_method == "LHS":
+
+        return latin.sample(problem=problem_dict,
+                            N=n_samples,
+                            seed=seed_value).T
+
+    else:
+        raise KeyError(f"Selected sampling method is not currently supported.  Please file a feature request here: https://github.com/IMMM-SFA/statemodify/issues")

--- a/statemodify/tests/test_eva.py
+++ b/statemodify/tests/test_eva.py
@@ -11,7 +11,6 @@ import statemodify as stm
 class TestEva(unittest.TestCase):
 
     VALID_MODIFY_DICT = {
-        "names": ["municipal", "standard"],
         "ids": [["10001", "10004"], ["10005", "10006"]],
         "bounds": [[-1.0, 1.0], [-1.0, 1.0]]
     }

--- a/statemodify/tests/test_eva.py
+++ b/statemodify/tests/test_eva.py
@@ -1,0 +1,37 @@
+import os
+import pkg_resources
+import unittest
+
+import statemodify as stm
+
+
+class TestEva(unittest.TestCase):
+
+    def test_something(self):
+
+        # a dictionary to describe what you want to modify and the bounds for the LHS
+        setup_dict = {
+            "names": ["municipal", "standard"],
+            "ids": [["10001", "10004"], ["10005", "10006"]],
+            "bounds": [[-1.0, 1.0], [-1.0, 1.0]]
+        }
+
+        output_directory = pkg_resources.resource_filename("statemodify", "data")
+        scenario = "test"
+
+        # the number of samples you wish to generate
+        n_samples = 2
+
+        # seed value for reproducibility if so desired
+        seed_value = 123
+
+        # generate a batch of files using generated LHS
+        stm.modify_eva(modify_dict=setup_dict,
+                       output_dir=output_directory,
+                       scenario=scenario,
+                       n_samples=n_samples,
+                       seed_value=seed_value)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/statemodify/tests/test_eva.py
+++ b/statemodify/tests/test_eva.py
@@ -1,36 +1,77 @@
 import os
 import pkg_resources
+import tempfile
 import unittest
+
+import numpy as np
 
 import statemodify as stm
 
 
 class TestEva(unittest.TestCase):
 
-    def test_something(self):
+    VALID_MODIFY_DICT = {
+        "names": ["municipal", "standard"],
+        "ids": [["10001", "10004"], ["10005", "10006"]],
+        "bounds": [[-1.0, 1.0], [-1.0, 1.0]]
+    }
 
-        # a dictionary to describe what you want to modify and the bounds for the LHS
-        setup_dict = {
-            "names": ["municipal", "standard"],
-            "ids": [["10001", "10004"], ["10005", "10006"]],
-            "bounds": [[-1.0, 1.0], [-1.0, 1.0]]
-        }
+    EVA_COMP_FILE_NAME = "template_scenario-test_sample-0.eva"
+    EVA_COMP_FULLPATH = pkg_resources.resource_filename("statemodify", os.path.join("data", EVA_COMP_FILE_NAME))
 
-        output_directory = pkg_resources.resource_filename("statemodify", "data")
-        scenario = "test"
+    def test_modify_single_eva_run(self):
+        """Ensure the single file processor runs and generates the expected output."""
 
-        # the number of samples you wish to generate
-        n_samples = 2
+        with tempfile.TemporaryDirectory() as tmp_dir:
 
-        # seed value for reproducibility if so desired
-        seed_value = 123
+            stm.modify_single_eva(modify_dict=TestEva.VALID_MODIFY_DICT,
+                                  query_field="id",
+                                  sample=np.array([0.39293837, -0.42772133]),
+                                  sample_id=0,
+                                  output_dir=tmp_dir,
+                                  scenario="test",
+                                  skip_rows=1,
+                                  template_file=None)
 
-        # generate a batch of files using generated LHS
-        stm.modify_eva(modify_dict=setup_dict,
-                       output_dir=output_directory,
-                       scenario=scenario,
-                       n_samples=n_samples,
-                       seed_value=seed_value)
+            # get contents of comparison file
+            with open(TestEva.EVA_COMP_FULLPATH) as comp:
+                comp_data = comp.read()
+
+            # get contents of generated file
+            with open(os.path.join(tmp_dir, TestEva.EVA_COMP_FILE_NAME)) as sim:
+                sim_data = sim.read()
+
+            # ensure equality
+            self.assertEqual(comp_data, sim_data, msg="Simulated data for EVA file does not match what was expected.")
+
+
+    def test_modify_eva_run(self):
+        """Ensure the parallel function runs and generates an expected output."""
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+
+            # generate a batch of files using generated LHS
+            stm.modify_eva(modify_dict=TestEva.VALID_MODIFY_DICT,
+                           query_field="id",
+                           output_dir=tmp_dir,
+                           scenario="test",
+                           sampling_method="LHS",
+                           n_samples=1,
+                           skip_rows=1,
+                           n_jobs=1,
+                           seed_value=123,
+                           template_file=None)
+
+            # get contents of comparison file
+            with open(TestEva.EVA_COMP_FULLPATH) as comp:
+                comp_data = comp.read()
+
+            # get contents of generated file
+            with open(os.path.join(tmp_dir, TestEva.EVA_COMP_FILE_NAME)) as sim:
+                sim_data = sim.read()
+
+            # ensure equality
+            self.assertEqual(comp_data, sim_data, msg="Simulated data for EVA file does not match what was expected in parallel function.")
 
 
 if __name__ == '__main__':

--- a/statemodify/tests/test_sampler.py
+++ b/statemodify/tests/test_sampler.py
@@ -18,17 +18,34 @@ class TestSampler(unittest.TestCase):
         "bounds": [[-1.0, 1.0], [-1.0, 1.0]]
     }
 
+    VALID_MODIFY_DICT_NONAMES = {
+        "ids": [["10001", "10004"], ["10005", "10006"]],
+        "bounds": [[-1.0, 1.0], [-1.0, 1.0]]
+    }
+
     PROBLEM_DICT = {
         'num_vars': 2,
         'names': ['municipal', 'standard'],
         'bounds': [[-1.0, 1.0], [-1.0, 1.0]]
     }
 
-    def test_validate_modify_dict(self):
+    FILL_COMP_DICT = {'ids': [['10001', '10004'], ['10005', '10006']],
+                      'bounds': [[-1.0, 1.0], [-1.0, 1.0]],
+                      'names': ['group_0', 'group_1']
+    }
+
+    def test_validate_modify_dict_fail(self):
         """Ensure validation raises error."""
 
         with self.assertRaises(KeyError):
-            sampler.validate_modify_dict(TestSampler.INVALID_MODIFY_DICT)
+            d = sampler.validate_modify_dict(TestSampler.INVALID_MODIFY_DICT, fill=False)
+
+    def test_validate_modify_dict_fill(self):
+        """Ensure validation fills missing names."""
+
+        d = sampler.validate_modify_dict(TestSampler.VALID_MODIFY_DICT_NONAMES, fill=True)
+
+        self.assertEqual(TestSampler.FILL_COMP_DICT, d)
 
     def test_build_problem_dict(self):
         """Ensure expected output is generated."""
@@ -47,8 +64,8 @@ class TestSampler(unittest.TestCase):
                                           sampling_method="LHS",
                                           seed_value=123)
 
-        expected_result = np.array([[-0.30353081, 0.22685145],
-                                    [0.55131477, -0.71386067]])
+        expected_result = np.array([[-0.30353081, 0.55131477],
+                                    [0.22685145, -0.71386067]])
 
         np.testing.assert_array_equal(np.around(expected_result, 4),
                                       np.around(result, 4))

--- a/statemodify/tests/test_sampler.py
+++ b/statemodify/tests/test_sampler.py
@@ -1,0 +1,67 @@
+import unittest
+
+import numpy as np
+
+import statemodify.sampler as sampler
+
+
+class TestSampler(unittest.TestCase):
+
+    VALID_MODIFY_DICT = {
+        "names": ["municipal", "standard"],
+        "ids": [["10001", "10004"], ["10005", "10006"]],
+        "bounds": [[-1.0, 1.0], [-1.0, 1.0]]
+    }
+
+    INVALID_MODIFY_DICT = {
+        "ids": [["10001", "10004"], ["10005", "10006"]],
+        "bounds": [[-1.0, 1.0], [-1.0, 1.0]]
+    }
+
+    PROBLEM_DICT = {
+        'num_vars': 2,
+        'names': ['municipal', 'standard'],
+        'bounds': [[-1.0, 1.0], [-1.0, 1.0]]
+    }
+
+    def test_validate_modify_dict(self):
+        """Ensure validation raises error."""
+
+        with self.assertRaises(KeyError):
+            sampler.validate_modify_dict(TestSampler.INVALID_MODIFY_DICT)
+
+    def test_build_problem_dict(self):
+        """Ensure expected output is generated."""
+
+        result = sampler.build_problem_dict(TestSampler.VALID_MODIFY_DICT)
+
+        self.assertEqual(TestSampler.PROBLEM_DICT,
+                         result,
+                         msg="Expected output was not achieved.")
+
+    def test_generate_samples_outcome(self):
+        """Ensure sample generator is functioning correctly."""
+
+        result = sampler.generate_samples(problem_dict=TestSampler.PROBLEM_DICT,
+                                          n_samples=2,
+                                          sampling_method="LHS",
+                                          seed_value=123)
+
+        expected_result = np.array([[-0.30353081, 0.22685145],
+                                    [0.55131477, -0.71386067]])
+
+        np.testing.assert_array_equal(np.around(expected_result, 4),
+                                      np.around(result, 4))
+
+    def test_generate_samples_failure(self):
+        """Ensure sample generator is failing correctly."""
+
+        with self.assertRaises(KeyError):
+            result = sampler.generate_samples(problem_dict=TestSampler.PROBLEM_DICT,
+                                              n_samples=2,
+                                              sampling_method="zzzz",
+                                              seed_value=123)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Purpose**:
Repair and update current functionality for `eva` file modification.  @rg727 noted run failure in #6 

Additionally, more functions were generalized for broader package use which yielded an additional sampler module.

**Implementation:**:

Generate a batch of `eva` files off of a template:
```python

import statemodify as stm

# a dictionary to describe what you want to modify and the bounds for the LHS
setup_dict = {
    "ids": [["10001", "10004"], ["10005", "10006"]],
    "bounds": [[-1.0, 1.0], [-1.0, 1.0]]
}

output_directory = "<your desired output directory>"
scenario = "<your scenario name>"

# the number of samples you wish to generate
n_samples = 4

# seed value for reproducibility if so desired
seed_value = None

# number of rows to skip in file after comment
skip_rows = 1

# name of field to query
query_field = "id"

# number of jobs to launch in parallel; -1 is all but 1 processor used
n_jobs = -1

# generate a batch of files using generated LHS
stm.modify_eva(modify_dict=modify_dict,
               query_field=query_field,
               output_dir=output_dir,
               scenario=scenario,
               sampling_method="LHS",
               n_samples=n_samples,
               skip_rows=skip_rows,
               n_jobs=n_jobs,
               seed_value=seed_value,
               template_file=None)
```

**Process**:

The following outlines the current implementation and functionality of this approach:

1. The user provides a dictionary of IDs to modify per each desired bounds like the following:

```python
modify_dict = {
        "ids": [["10001", "10004"], ["10005", "10006"]],
        "bounds": [[-1.0, 1.0], [-1.0, 1.0]]
}
```

2. The code above converts this to a dictionary that can be used by `SALib` to generate a sample array.  The sample array is generated and renders a set of parameter values per id, per requested number of samples.  So using the above dictionary from the user, and requesting two samples would return the following:

```bash
array([[-0.30353081,  0.55131477],
       [ 0.22685145, -0.71386067]])
```

3. Each sample for each ID set (e.g., [-0.30353081,  0.55131477] for IDs ["10001", "10004"]) is used to modify the input template EVA file by searching for the target IDs in the file and multiplying the existing values for each target ID by the factor generated by the sample. The template file comes with the package by default, but the user can pass in their own as well.

4. Each modified file is written to the user specified location and contains the source filename, scenario, and sample ID in its new file name.

**Considerations**:

- @rg727 Should we place in other metrics for adjusting initial values in the template instead of just multiplying the existing values per the factor (sample)?  





