### PR TITLE
Add save_sample option to write sample to file

### DIFF
--- a/statemodify/ddm.py
+++ b/statemodify/ddm.py
@@ -1,3 +1,4 @@
+import os
 from typing import Union, Dict, List
 
 import numpy as np
@@ -222,7 +223,8 @@ def modify_ddm(modify_dict: Dict[str, List[Union[str, float]]],
                factor_method: str = "multiply",
                data_specification_file: Union[None, str] = None,
                min_bound_value: float = 0.5,
-               max_bound_value: float = 1.5) -> None:
+               max_bound_value: float = 1.5,
+               save_sample: bool = False) -> None:
     """Parallel modification of StateMod municipal, industrial, transbasin Demands (.ddm) using a Latin Hypercube Sample
     from the user. Samples are processed in parallel. Modification is targeted at 'municipal' and 'standard' fields
     where ids to modify are specified in the `modify_dict` argument. The user must specify bounds for each field name.
@@ -284,6 +286,10 @@ def modify_ddm(modify_dict: Dict[str, List[Union[str, float]]],
                                         Maximum allowable value:  1.5
     :type max_bound_value:              float
 
+    :param save_sample:         Choice to save LHS sample or not; default False.  If True, sample array will be written
+                                to the output directory.
+    :type save_sample:          bool
+
     :return: None
     :rtype: None
 
@@ -336,7 +342,8 @@ def modify_ddm(modify_dict: Dict[str, List[Union[str, float]]],
                        factor_method="multiply",
                        data_specification_file=None,
                        min_bound_value=-0.5,
-                       max_bound_value=1.0)
+                       max_bound_value=1.0,
+                       save_sample=False)
 
     """
 
@@ -348,6 +355,11 @@ def modify_ddm(modify_dict: Dict[str, List[Union[str, float]]],
                                             n_samples=n_samples,
                                             sampling_method=sampling_method,
                                             seed_value=seed_value)
+
+    # if the user chooses, write the sample to file
+    if save_sample:
+        sample_file = os.path.join(output_dir, f"ddm_{n_samples}-samples_scenario-{scenario}.npy")
+        np.save(sample_file, sample_array)
 
     # generate all files in parallel
     results = Parallel(n_jobs=n_jobs, backend="loky")(delayed(modify_single_ddm)(modify_dict=modify_dict,

--- a/statemodify/ddr.py
+++ b/statemodify/ddr.py
@@ -1,3 +1,4 @@
+import os
 from typing import Union, Dict, List
 
 import numpy as np
@@ -342,7 +343,8 @@ def modify_ddr(modify_dict: Dict[str, List[Union[str, float]]],
                factor_method: str = "multiply",
                data_specification_file: Union[None, str] = None,
                min_bound_value: float = 0.5,
-               max_bound_value: float = 1.5) -> None:
+               max_bound_value: float = 1.5,
+               save_sample: bool = False) -> None:
     """Parallelized modification of StateMod water rights (.ddr) using a Latin Hypercube Sample from the user.
     Samples are processed in parallel. Modification is targeted at ids chosen by the user to
     modify and specified in the `modify_dict` argument.  The user must specify bounds for each field name.
@@ -403,6 +405,10 @@ def modify_ddr(modify_dict: Dict[str, List[Union[str, float]]],
     :param max_bound_value:             Maximum feasible sampling bounds in feet per month.
                                         Maximum allowable value:  1.0
     :type max_bound_value:              float
+
+    :param save_sample:         Choice to save LHS sample or not; default False.  If True, sample array will be written
+                                to the output directory.
+    :type save_sample:          bool
 
     :return: None
     :rtype: None
@@ -467,7 +473,8 @@ def modify_ddr(modify_dict: Dict[str, List[Union[str, float]]],
                        factor_method="multiply",
                        data_specification_file=None,
                        min_bound_value=-0.5,
-                       max_bound_value=1.0)
+                       max_bound_value=1.0,
+                       save_sample=False)
 
     """
 
@@ -500,6 +507,11 @@ def modify_ddr(modify_dict: Dict[str, List[Union[str, float]]],
                                                 n_samples=n_samples,
                                                 sampling_method=sampling_method,
                                                 seed_value=seed_value)
+
+    # if the user chooses, write the sample to file
+    if save_sample:
+        sample_file = os.path.join(output_dir, f"ddr_{n_samples}-samples_scenario-{scenario}.npy")
+        np.save(sample_file, sample_array)
 
     # generate all files in parallel
     results = Parallel(n_jobs=n_jobs, backend="loky")(delayed(modify_single_ddr)(modify_dict=modify_dict,

--- a/statemodify/eva.py
+++ b/statemodify/eva.py
@@ -1,4 +1,4 @@
-import pkg_resources
+import os
 from typing import Union, Dict, List
 
 import numpy as np
@@ -219,8 +219,8 @@ def modify_eva(modify_dict: Dict[str, List[Union[str, float]]],
                factor_method: str = "add",
                data_specification_file: Union[None, str] = None,
                min_bound_value: float = -0.5,
-               max_bound_value: float = 1.0
-               ) -> None:
+               max_bound_value: float = 1.0,
+               save_sample: bool = False) -> None:
     """Modify StateMod net reservoir evaporation annual data file (.eva) using a Latin Hypercube Sample from the user.
     Samples are processed in parallel. Modification is targeted at ids chosen by the user to
     modify and specified in the `modify_dict` argument.  The user must specify bounds for each field name.
@@ -282,6 +282,10 @@ def modify_eva(modify_dict: Dict[str, List[Union[str, float]]],
                                         Maximum allowable value:  1.0
     :type max_bound_value:              float
 
+    :param save_sample:         Choice to save LHS sample or not; default False.  If True, sample array will be written
+                                to the output directory.
+    :type save_sample:          bool
+
     :return: None
     :rtype: None
 
@@ -333,7 +337,8 @@ def modify_eva(modify_dict: Dict[str, List[Union[str, float]]],
                        factor_method="add",
                        data_specification_file=None,
                        min_bound_value=-0.5,
-                       max_bound_value=1.0)
+                       max_bound_value=1.0,
+                       save_sample=False)
 
     """
 
@@ -345,6 +350,11 @@ def modify_eva(modify_dict: Dict[str, List[Union[str, float]]],
                                             n_samples=n_samples,
                                             sampling_method=sampling_method,
                                             seed_value=seed_value)
+
+    # if the user chooses, write the sample to file
+    if save_sample:
+        sample_file = os.path.join(output_dir, f"eva_{n_samples}-samples_scenario-{scenario}.npy")
+        np.save(sample_file, sample_array)
 
     # generate all files in parallel
     results = Parallel(n_jobs=n_jobs, backend="loky")(delayed(modify_single_eva)(modify_dict=modify_dict,

--- a/statemodify/res.py
+++ b/statemodify/res.py
@@ -238,7 +238,8 @@ def modify_res(output_dir: str,
                skip_rows: int = 0,
                seed_value: Union[None, int] = None,
                n_jobs: int = -1,
-               n_samples: int = 1):
+               n_samples: int = 1,
+               save_sample: bool = False):
     """Modify a single reservoir (.res) file based on a user provided sample.
 
     :param output_dir:          Path to output directory.
@@ -285,6 +286,10 @@ def modify_res(output_dir: str,
     :param n_samples:                       Used if generate_samples is True.  Number of samples to generate.
     :type n_samples:                        int
 
+    :param save_sample:         Choice to save LHS sample or not; default False.  If True, sample array will be written
+                                to the output directory.
+    :type save_sample:          bool
+
     :example:
 
     .. code-block:: python
@@ -313,7 +318,8 @@ def modify_res(output_dir: str,
                        target_structure_id_list=None,
                        seed_value=seed_value,
                        n_jobs=n_jobs,
-                       n_samples=n_samples)
+                       n_samples=n_samples,
+                       save_sample=False)
 
     """
 
@@ -323,6 +329,11 @@ def modify_res(output_dir: str,
     # generate an array of samples to process
     sample_array = sampler.generate_sample_all_params(n_samples=n_samples,
                                                       seed_value=seed_value)
+
+    # if the user chooses, write the sample to file
+    if save_sample:
+        sample_file = os.path.join(output_dir, f"res_{n_samples}-samples_scenario-{scenario}.npy")
+        np.save(sample_file, sample_array)
 
     # generate all files in parallel
     results = Parallel(n_jobs=n_jobs, backend="loky")(delayed(modify_single_res)(output_dir=output_dir,

--- a/statemodify/xbm_iwr.py
+++ b/statemodify/xbm_iwr.py
@@ -859,7 +859,8 @@ def modify_xbm_iwr(output_dir: str,
                    months_in_year: int = 12,
                    seed_value: Union[None, int] = None,
                    n_jobs: int = -1,
-                   n_samples: int = 1):
+                   n_samples: int = 1,
+                   save_sample: bool = False):
     """Generate flows for all samples for all basins in parallel to build modified XBM and IWR files.
 
     :param output_dir:                      Path to output directory.
@@ -913,6 +914,10 @@ def modify_xbm_iwr(output_dir: str,
     :param n_samples:                       Used if generate_samples is True.  Number of samples to generate.
     :type n_samples:                        int
 
+    :param save_sample:         Choice to save LHS sample or not; default False.  If True, sample array will be written
+                                to the output directory.
+    :type save_sample:          bool
+
     :example:
 
     .. code-block:: python
@@ -941,7 +946,8 @@ def modify_xbm_iwr(output_dir: str,
                            basin_name=basin_name,
                            seed_value=seed_value,
                            n_jobs=n_jobs,
-                           n_samples=n_samples)
+                           n_samples=n_samples,
+                           save_sample=False)
 
 
     """
@@ -952,6 +958,11 @@ def modify_xbm_iwr(output_dir: str,
     # generate an array of samples to process
     sample_array = sampler.generate_sample_all_params(n_samples=n_samples,
                                                       seed_value=seed_value)
+
+    # if the user chooses, write the sample to file
+    if save_sample:
+        sample_file = os.path.join(output_dir, f"xbm-iwr_{n_samples}-samples_scenario-{scenario}.npy")
+        np.save(sample_file, sample_array)
 
     # generate all files in parallel
     results = Parallel(n_jobs=n_jobs, backend="loky")(delayed(modify_single_xbm_iwr)(mu_0=sample[param_dict["mu0"]["index"]],


### PR DESCRIPTION
**Description:**
Add `save_sample` option to file modify functions to allow writing the samples to file.

**Example:**
Setting `save_sample` to `True` will write the sample array as a `npy` file in the location specified by the `output_dir` argument:
```python
import statemodify as stm

# a dictionary to describe what you want to modify and the bounds for the LHS
setup_dict = {
  "names": ["municipal", "standard"],
  "ids": [["3600507", "3600603"], ["3600649_D", "3600662_D"]],
  "bounds": [[0.5, 1.0], [0.5, 1.0]]
}

output_directory = "<your desired output directory>"
scenario = "<your scenario name>"

# the number of samples you wish to generate
n_samples = 4

# seed value for reproducibility if so desired
seed_value = None

# number of rows to skip in file after comment
skip_rows = 1

# name of field to query
query_field = "id"

# number of jobs to launch in parallel; -1 is all but 1 processor used
n_jobs = -1

# basin to process
basin_name = "Upper_Colorado"

# generate a batch of files using generated LHS
stm.modify_ddm(modify_dict=setup_dict,
             query_field=query_field,
             output_dir=output_directory,
             scenario=scenario,
             basin_name=basin_name,
             sampling_method="LHS",
             n_samples=n_samples,
             skip_rows=skip_rows,
             n_jobs=n_jobs,
             seed_value=seed_value,
             template_file=None,
             factor_method="multiply",
             data_specification_file=None,
             min_bound_value=-0.5,
             max_bound_value=1.0,
             save_sample=True)
```
The sample can the be reloaded via:
```python
import numpy as np

sample_array = np.load("<sample_file_path_and_name_with_extension>")
```
